### PR TITLE
fix: add missing package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6865,6 +6865,11 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "later": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/later/-/later-1.2.0.tgz",
+      "integrity": "sha1-8s9sTdeVbdL1IK3wMpg26YdrrQ8="
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@reactioncommerce/api-utils": "^1.9.0",
     "@reactioncommerce/logger": "^1.1.3",
     "@reactioncommerce/random": "^1.0.2",
+    "later": "^1.2.0",
     "simpl-schema": "^1.5.7"
   },
   "devDependencies": {


### PR DESCRIPTION
When removing the `later` package from the core api, it triggered an error because `api-plugin-job-queue` needs this package.

This PR adds the package.